### PR TITLE
Removes -for-wordpress slug everywhere

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ patches and features.
 
 ## Using the issue tracker
 
-The [issue tracker](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/issues) is
+The [issue tracker](https://github.com/pantheon-systems/pantheon-content-publisher/issues) is
 the preferred channel for [bug reports](#bug-reports), [features requests](#feature-requests)
 and [submitting pull requests](#pull-requests), but please respect the following
 restrictions:
@@ -40,7 +40,7 @@ them:
 - `question` - General support/questions issue bucket.
 
 For a complete look at our labels, see
-the [project labels page](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/labels).
+the [project labels page](https://github.com/pantheon-systems/pantheon-content-publisher/labels).
 
 ## Bug reports
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,13 +6,13 @@ labels: bug
 
 Before opening:
 
-- [Search for duplicate or closed issues](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/issues?utf8=%E2%9C%93&q=is%3Aissue)
+- [Search for duplicate or closed issues](https://github.com/pantheon-systems/pantheon-content-publisher/issues?utf8=%E2%9C%93&q=is%3Aissue)
 - Validate
-  and [lint](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/master/phpcs.xml) any PHP
+  and [lint](https://github.com/pantheon-systems/pantheon-content-publisher/blob/master/phpcs.xml) any PHP
   code to avoid
   common problems
 - Read
-  the [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/.github/CONTRIBUTING.md)
+  the [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/.github/CONTRIBUTING.md)
 
 Bug reports must include:
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,9 +6,9 @@ labels: feature
 
 Before opening:
 
-- [Search for duplicate or closed issues](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/issues?utf8=%E2%9C%93&q=is%3Aissue)
+- [Search for duplicate or closed issues](https://github.com/pantheon-systems/pantheon-content-publisher/issues?utf8=%E2%9C%93&q=is%3Aissue)
 - Read
-  the [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/master/.github/CONTRIBUTING.md)
+  the [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher/blob/master/.github/CONTRIBUTING.md)
 
 Feature requests must include:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 
 - [ ] I've tested the code.
 - [ ] My code follows the repository code
-  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/phpcs.xml/ -->
+  style. <!-- Ruleset: https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/phpcs.xml/ -->
 - [ ] My code follows the accessibility
   standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
 - [ ] My code follows the PHP DocBlock documentation

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -31,7 +31,7 @@ version-resolver:
       - 'patch'
   default: patch
 template: |
-  ## [v$RESOLVED_VERSION(####-##-##)](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/compare/$PREVIOUS_TAG...$RESOLVED_VERSION)
+  ## [v$RESOLVED_VERSION(####-##-##)](https://github.com/pantheon-systems/pantheon-content-publisher/compare/$PREVIOUS_TAG...$RESOLVED_VERSION)
 
   $CHANGES
 

--- a/.github/release.sh
+++ b/.github/release.sh
@@ -10,7 +10,7 @@ INCLUDES=(
     "app"
     "assets"
     "dist"
-    "pantheon-content-publisher-for-wordpress.php"
+    "pantheon-content-publisher.php"
     "vendor"
 )
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ dist/
 .DS_Store
 *.code-workspace
 .idea
-pantheon-content-publisher-for-wordpress.zip
+pantheon-content-publisher.zip

--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@
 <p align="center">
   <i>Publish WordPress content from Google Docs with Pantheon Content Cloud.</i>
   <br>
-  <a href="https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/issues/new?template=bug_report.md&labels=bug">Report bug</a>
+  <a href="https://github.com/pantheon-systems/pantheon-content-publisher/issues/new?template=bug_report.md&labels=bug">Report bug</a>
   ·
-  <a href="https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/issues/new?template=feature_request.md&labels=feature">Request feature</a>
+  <a href="https://github.com/pantheon-systems/pantheon-content-publisher/issues/new?template=feature_request.md&labels=feature">Request feature</a>
   ·
   <a href="https://pcc.pantheon.io/docs" target="_blank">Check out PCC Docs</a>
 </p>
 
 <div align="center">
 
-[![Style Lint](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/actions/workflows/php-style-lint.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/actions/workflows/php-style-lint.yml)
-[![PHP Compatibility 8.x](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/actions/workflows/php-version-compatibility.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/actions/workflows/php-version-compatibility.yml)
+[![Style Lint](https://github.com/pantheon-systems/pantheon-content-publisher/actions/workflows/php-style-lint.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-content-publisher/actions/workflows/php-style-lint.yml)
+[![PHP Compatibility 8.x](https://github.com/pantheon-systems/pantheon-content-publisher/actions/workflows/php-version-compatibility.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-content-publisher/actions/workflows/php-version-compatibility.yml)
 
 </div>
 
@@ -42,17 +42,17 @@
 
 This is a WordPress plugin. It can be installed via the usual WordPress Dashboard workflow.
 
-- [Download the latest release.](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/releases/)
+- [Download the latest release.](https://github.com/pantheon-systems/pantheon-content-publisher/releases/)
 
 or
 
-- Clone the repo: `git clone https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress.git` in
+- Clone the repo: `git clone https://github.com/pantheon-systems/pantheon-content-publisher.git` in
   your `wp-content/plugins`
   folder
 
-or
+**_or soon_**
 
-- Install via Composer: `composer require pantheon-systems/pantheon-content-publisher-for-wordpress`
+- Install via Composer: `composer require pantheon-systems/pantheon-content-publisher`
 
 **_If installing from source, make sure to follow the build instructions in the [Development](#development) section
 below_**
@@ -62,18 +62,18 @@ below_**
 1. `composer i && npm i` to install dependencies.
 2. `npm run watch` / `npm run dev` / `npm run prod` to build assets.
 3. Read through
-   our [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/.github/CONTRIBUTING.md)
+   our [contributing guidelines](https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/.github/CONTRIBUTING.md)
    for additional information. Included are directions for opening issues, coding standards and miscellaneous notes.
 
 ## Repository Actions
 
 This repository takes advantage of the following workflows to automate the release & testing processes:
 
-- [PHPCS](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/.github/workflows/php-style-lint.yml)
-- [PHPCompatibility](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/.github/workflows/php-version-compatibility.yml)
+- [PHPCS](https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/.github/workflows/php-style-lint.yml)
+- [PHPCompatibility](https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/.github/workflows/php-version-compatibility.yml)
 - [Release Drafter](https://github.com/marketplace/actions/release-drafter)
 - [PR Labeler](https://github.com/marketplace/actions/pr-labeler)
-- [A custom workflow that builds release artifacts](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/.github/workflows/release-artifact.yml)
+- [A custom workflow that builds release artifacts](https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/.github/workflows/release-artifact.yml)
 
 These workflows will build a release draft and keep it up-to-date as new PRs are merged. Once a release is published, a
 ready-to-install zip file will be generated and attached to the newly-published release.
@@ -96,9 +96,9 @@ Pantheon Content Publisher is dependent on:
 ## Bugs and feature requests
 
 Have a bug or a feature request? Please first read
-the [issue guidelines](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/blob/primary/.github/CONTRIBUTING.md#using-the-issue-tracker)
+the [issue guidelines](https://github.com/pantheon-systems/pantheon-content-publisher/blob/primary/.github/CONTRIBUTING.md#using-the-issue-tracker)
 and search for existing and closed issues. If your problem or idea is not addressed
-yet, [please open a new issue](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/issues/new).
+yet, [please open a new issue](https://github.com/pantheon-systems/pantheon-content-publisher/issues/new).
 
 ## Documentation
 
@@ -113,5 +113,5 @@ adhere to those rules whenever possible.
 ## Changelog
 
 You may find changelogs for each version of Pantheon Content Publisher released
-in [the Releases section](https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/releases) of this
+in [the Releases section](https://github.com/pantheon-systems/pantheon-content-publisher/releases) of this
 repository.

--- a/admin/templates/partials/connected-collection.php
+++ b/admin/templates/partials/connected-collection.php
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) {
 			<?php require CONTENT_PUB_PLUGIN_DIR . 'admin/templates/partials/error-message.php'; ?>
 			<div class="py-2.5">
 				<h3 class="text-grey font-bold text-sm mb-[0.5rem]">
-					<?php esc_html_e('Connected content collection', 'pantheon-content-publisher-for-wordpress') ?>
+					<?php esc_html_e('Connected content collection', 'pantheon-content-publisher') ?>
 				</h3>
 				<div class="page-grid mb-9">
 					<div class="col-span-8 justify-self-start break-all">
@@ -27,18 +27,18 @@ if (!defined('ABSPATH')) {
 					</div>
 					<a class="secondary-button self-start col-span-4 justify-self-end" 
 						href="<?php echo esc_url(add_query_arg([
-						'page' => 'pantheon-content-publisher-for-wordpress',
+						'page' => 'pantheon-content-publisher',
 						'view' => 'disconnect-confirmation'
 					], admin_url('admin.php'))) ?>">
 						<span>
-							<?php esc_html_e('Disconnect collection', 'pantheon-content-publisher-for-wordpress') ?>
+							<?php esc_html_e('Disconnect collection', 'pantheon-content-publisher') ?>
 						</span>
 					</a>
 				</div>
 				<div>
 					<div class="divider-border"></div>
 					<p class="text-lg font-bold mt-10 mb-[1.25rem]">
-						<?php esc_html_e('Publish your document as:', 'pantheon-content-publisher-for-wordpress') ?>
+						<?php esc_html_e('Publish your document as:', 'pantheon-content-publisher') ?>
 					</p>
 					<div class="inputs-container">
 						<div class='input-wrapper'>
@@ -65,7 +65,7 @@ if (!defined('ABSPATH')) {
 						</div>
 					</div>
 					<a class="primary-button" id="pcc-update-collection" href="#">
-						<?php esc_html_e('Save configuration', 'pantheon-content-publisher-for-wordpress') ?>
+						<?php esc_html_e('Save configuration', 'pantheon-content-publisher') ?>
 					</a>
 				</div>
 			</div>

--- a/admin/templates/partials/create-collection.php
+++ b/admin/templates/partials/create-collection.php
@@ -16,17 +16,18 @@ if (!defined('ABSPATH')) {
 				<div class="page-grid">
 					<div class="col-span-7 justify-self-start">
 						<h1 class="page-header mt-[1.875rem]">
-							<?php esc_html_e('Create your first content collection', 'pantheon-content-publisher-for-wordpress') ?>
+							<?php esc_html_e('Create your first content collection', 'pantheon-content-publisher') ?>
 						</h1>
 						<p class="page-description mb-8">
 							<?php esc_html_e('Just one more step!
 						A content collection is a set of content for your WordPress site.
 						Connected to Google Workspace,
-						it helps you organize and manage your site content in Google Docs.', 'pantheon-content-publisher-for-wordpress') ?>
+						it helps you organize and manage your site content in Google Docs.',
+						 'pantheon-content-publisher') ?>
 						</p>
 						<p class="text-with-border mb-[1.875rem]"><?php echo esc_url(site_url()) ?></p>
 						<p class="text-lg font-bold mb-[1.25rem]" >
-							<?php esc_html_e('Publish your document as:', 'pantheon-content-publisher-for-wordpress') ?>
+							<?php esc_html_e('Publish your document as:', 'pantheon-content-publisher') ?>
 						</p>
 						<div class="inputs-container">
 							<div class='input-wrapper'>
@@ -61,11 +62,11 @@ if (!defined('ABSPATH')) {
 							</div>
 						</div>
 						<a class="primary-button" id="pcc-create-site" href="#">
-							<?php esc_html_e('Create collection', 'pantheon-content-publisher-for-wordpress') ?>
+							<?php esc_html_e('Create collection', 'pantheon-content-publisher') ?>
 						</a>
 						<div class="mb-10">
 							<a class="secondary-button self-start justify-self-end" id="pcc-disconnect" href="#">
-								<?php esc_html_e('Reset your Google Workspace authentication', 'pantheon-content-publisher-for-wordpress') ?>
+								<?php esc_html_e('Reset your Google Workspace authentication', 'pantheon-content-publisher') ?>
 							</a>
 						</div>
 					</div>

--- a/admin/templates/partials/disconnect-confirmation.php
+++ b/admin/templates/partials/disconnect-confirmation.php
@@ -19,7 +19,7 @@ if (!defined('ABSPATH')) {
 							<?php
 							esc_html_e(
 								'Are you sure you want to disconnect the content collection?',
-								'pantheon-content-publisher-for-wordpress'
+								'pantheon-content-publisher'
 							)
 							?>
 						</h1>
@@ -27,24 +27,24 @@ if (!defined('ABSPATH')) {
 							<?php esc_html_e(
 								'All Google Docs in the collection will be disconnected from your site
                             , and you wont be able to update site content in Google Docs anymore.',
-								'pantheon-content-publisher-for-wordpress'
+								'pantheon-content-publisher'
 							) ?>
 						</p>
 						<p class="page-description">
 							<?php esc_html_e(
 								'The content will remain on the site, manageable using the WordPress admin interface.',
-								'pantheon-content-publisher-for-wordpress'
+								'pantheon-content-publisher'
 							) ?>
 						</p>
 						<div class="flex gap-4 mt-[1.875rem]">
 							<a class="secondary-button"
 							   href="<?php echo esc_url(add_query_arg([
-								   'page' => 'pantheon-content-publisher-for-wordpress',
+								   'page' => 'pantheon-content-publisher',
 								   'view' => 'connected-collection'], admin_url('admin.php'))) ?>">
-								<?php esc_html_e('Stay connected', 'pantheon-content-publisher-for-wordpress') ?>
+								<?php esc_html_e('Stay connected', 'pantheon-content-publisher') ?>
 							</a>
 							<a class="danger-button" id="pcc-disconnect" href="#">
-								<?php esc_html_e('Disconnect', 'pantheon-content-publisher-for-wordpress') ?>
+								<?php esc_html_e('Disconnect', 'pantheon-content-publisher') ?>
 							</a>
 						</div>
 					</div>

--- a/admin/templates/partials/footer.php
+++ b/admin/templates/partials/footer.php
@@ -8,10 +8,10 @@ if (!defined('ABSPATH')) {
 	<div class="divider-border"></div>
 	<div class="pt-[0.4rem]">
 		<span class="text-base">
-			<?php esc_html_e('For detailed instructions on publishing content from Google Docs,', 'pantheon-content-publisher-for-wordpress') ?>
+			<?php esc_html_e('For detailed instructions on publishing content from Google Docs,', 'pantheon-content-publisher') ?>
 		</span>
 		<a href="https://pcc.pantheon.io/docs" class="documentation-link" target="_blank">
-			<span class="text-base"><?php esc_html_e('please refer to our documentation', 'pantheon-content-publisher-for-wordpress') ?></span>
+			<span class="text-base"><?php esc_html_e('please refer to our documentation', 'pantheon-content-publisher') ?></span>
 			<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px"
 				 y="0px"
 				 viewBox="0 0 100 125" xml:space="preserve"><title>61 all</title>

--- a/admin/templates/partials/header.php
+++ b/admin/templates/partials/header.php
@@ -8,5 +8,5 @@ if (!defined('ABSPATH')) {
 	<img src="<?php
 	echo esc_url(CONTENT_PUB_PLUGIN_DIR_URL . 'assets/images/pantheon-logo.svg') ?>" alt="Pantheon Logo">
 	<span class="header-title"><?php
-		esc_html_e('Content Publisher', 'pantheon-content-publisher-for-wordpress') ?></span>
+		esc_html_e('Content Publisher', 'pantheon-content-publisher') ?></span>
 </div>

--- a/admin/templates/partials/plugin-notification.php
+++ b/admin/templates/partials/plugin-notification.php
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) {
 					 alt="Pantheon Logo">
 				<span class="header-title">
 					<?php
-					esc_html_e('Content Publisher', 'pantheon-content-publisher-for-wordpress') ?>
+					esc_html_e('Content Publisher', 'pantheon-content-publisher') ?>
 				</span>
 			</div>
 			<div class="">
@@ -22,13 +22,13 @@ if (!defined('ABSPATH')) {
 					esc_html_e(
 						'Plugin installed! To create and publish content,
 					complete the setup by connecting Google Workspace to your WordPress site.',
-						'pantheon-content-publisher-for-wordpress'
+						'pantheon-content-publisher'
 					) ?>
 				</p>
 				<a href="<?php
-				echo esc_url(add_query_arg(['page' => 'pantheon-content-publisher-for-wordpress'], admin_url('admin.php'))) ?>"
+				echo esc_url(add_query_arg(['page' => 'pantheon-content-publisher'], admin_url('admin.php'))) ?>"
 				   class="primary-button me-auto"><?php
-					esc_html_e('Complete setup', 'pantheon-content-publisher-for-wordpress') ?>
+					esc_html_e('Complete setup', 'pantheon-content-publisher') ?>
 				</a>
 			</div>
 		</div>

--- a/admin/templates/partials/setup.php
+++ b/admin/templates/partials/setup.php
@@ -17,19 +17,19 @@ if (!defined('ABSPATH')) {
 					<div class="col-span-8">
 						<div class="w-[80%]">
 							<h1 class="page-header">
-								<?php esc_html_e('Connect Google Workspace to your WordPress site', 'pantheon-content-publisher-for-wordpress') ?>
+								<?php esc_html_e('Connect Google Workspace to your WordPress site', 'pantheon-content-publisher') ?>
 							</h1>
 							<p class="page-description">
 								<?php
 								esc_html_e(
 									'Effortlessly publish content from Google Docs to your WordPress site using 
 									Pantheon Content Publisher.',
-									'pantheon-content-publisher-for-wordpress'
+									'pantheon-content-publisher'
 								) ?>
 							</p>
 							<div class="mt-8 mb-0.5">
 							<span class="font-semibold text-[0.83rem]">
-								<?php esc_html_e('Management token', 'pantheon-content-publisher-for-wordpress') ?>
+								<?php esc_html_e('Management token', 'pantheon-content-publisher') ?>
 							</span>
 								<img class="scale-110 ms-1 pb-2.5 inline"
 									 src="<?php
@@ -43,7 +43,7 @@ if (!defined('ABSPATH')) {
 									<span class="tooltip-text">
 									<?php
 									esc_html_e('Enter the management token obtained from
-                                    the Pantheon Content Publisher dashboard', 'pantheon-content-publisher-for-wordpress') ?>
+                                    the Pantheon Content Publisher dashboard', 'pantheon-content-publisher') ?>
 								</span>
 								</div>
 
@@ -53,7 +53,7 @@ if (!defined('ABSPATH')) {
 								   id="access-token"
 								   name="access_token" class="input-with-border mb-2" required/>
 							<button id="pcc-app-authenticate" class="primary-button">
-								<?php esc_html_e('Connect', 'pantheon-content-publisher-for-wordpress') ?>
+								<?php esc_html_e('Connect', 'pantheon-content-publisher') ?>
 							</button>
 						</div>
 						<p class="text-base mt-8 mb-10">
@@ -65,7 +65,7 @@ if (!defined('ABSPATH')) {
 									__(
 										"Don't have a token yet? Go to the " .
 										"<a %s>Pantheon Content Publisher dashboard</a> to generate one.",
-										'pantheon-content-publisher-for-wordpress'
+										'pantheon-content-publisher'
 									),
 									'class="pantheon-link  hover:text-secondary" target="_blank" ' .
 									'href="https://content.pantheon.io/dashboard/settings/tokens?tab=1"'

--- a/app/RestController.php
+++ b/app/RestController.php
@@ -109,7 +109,7 @@ class RestController
 	{
 		if (get_option(CONTENT_PUB_WEBHOOK_SECRET_OPTION_KEY) !== $request->get_header('x-pcc-webhook-secret')) {
 			return new WP_REST_Response(
-				esc_html__('You are not authorized to perform this action', 'pantheon-content-publisher-for-wordpress'),
+				esc_html__('You are not authorized to perform this action', 'pantheon-content-publisher'),
 				401
 			);
 		}
@@ -121,13 +121,13 @@ class RestController
 		// Bail if current website id is not correctly configured
 		if (!$isPCCConfiguredCorrectly) {
 			return new WP_REST_Response(
-				esc_html__('Website is not correctly configured', 'pantheon-content-publisher-for-wordpress'),
+				esc_html__('Website is not correctly configured', 'pantheon-content-publisher'),
 				500
 			);
 		}
 
 		if (!is_array($payload) || !isset($payload['articleId']) || empty($payload['articleId'])) {
-			return new WP_REST_Response(esc_html__('Invalid article ID in payload', 'pantheon-content-publisher-for-wordpress'), 400);
+			return new WP_REST_Response(esc_html__('Invalid article ID in payload', 'pantheon-content-publisher'), 400);
 		}
 
 		$articleId = sanitize_text_field($payload['articleId']);
@@ -141,7 +141,7 @@ class RestController
 				break;
 			default:
 				return new WP_REST_Response(
-					esc_html__('Event type is currently unsupported', 'pantheon-content-publisher-for-wordpress'),
+					esc_html__('Event type is currently unsupported', 'pantheon-content-publisher'),
 					200
 				);
 		}
@@ -162,21 +162,21 @@ class RestController
 		$siteId = sanitize_text_field($request->get_param('site_id') ?: '');
 		if (!$siteId) {
 			return new WP_REST_Response([
-				'message' => esc_html__('Missing site id', 'pantheon-content-publisher-for-wordpress'),
+				'message' => esc_html__('Missing site id', 'pantheon-content-publisher'),
 			], 400);
 		}
 
 		$postType = sanitize_text_field($request->get_param('post_type') ?: '');
 		if (!$postType) {
 			return new WP_REST_Response([
-				'message' => esc_html__('Missing integration post type', 'pantheon-content-publisher-for-wordpress'),
+				'message' => esc_html__('Missing integration post type', 'pantheon-content-publisher'),
 			], 400);
 		}
 
 		update_option(CONTENT_PUB_SITE_ID_OPTION_KEY, $siteId);
 		update_option(CONTENT_PUB_INTEGRATION_POST_TYPE_OPTION_KEY, $postType);
 
-		return new WP_REST_Response(esc_html__('Saved!', 'pantheon-content-publisher-for-wordpress'));
+		return new WP_REST_Response(esc_html__('Saved!', 'pantheon-content-publisher'));
 	}
 
 	/**
@@ -187,11 +187,11 @@ class RestController
 	{
 		// Check if you are authorized
 		if (!current_user_can('manage_options')) {
-			return new WP_REST_Response(esc_html__('You are not authorized to perform this action.', 'pantheon-content-publisher-for-wordpress'), 401);
+			return new WP_REST_Response(esc_html__('You are not authorized to perform this action.', 'pantheon-content-publisher'), 401);
 		}
 		// Check management token is set
 		if (!get_option(CONTENT_PUB_ACCESS_TOKEN_OPTION_KEY)) {
-			return new WP_REST_Response(esc_html__('Management token is not set yet', 'pantheon-content-publisher-for-wordpress'), 401);
+			return new WP_REST_Response(esc_html__('Management token is not set yet', 'pantheon-content-publisher'), 401);
 		}
 
 		$siteManager = new PccSiteManager();
@@ -215,25 +215,25 @@ class RestController
 	{
 		// Check management token is set
 		if (!get_option(CONTENT_PUB_ACCESS_TOKEN_OPTION_KEY)) {
-			return new WP_REST_Response(esc_html__('Management token is not set yet', 'pantheon-content-publisher-for-wordpress'), 400);
+			return new WP_REST_Response(esc_html__('Management token is not set yet', 'pantheon-content-publisher'), 400);
 		}
 
 		// Check site id is set
 		if (!get_option(CONTENT_PUB_SITE_ID_OPTION_KEY)) {
-			return new WP_REST_Response(esc_html__('Site is not created yet', 'pantheon-content-publisher-for-wordpress'), 400);
+			return new WP_REST_Response(esc_html__('Site is not created yet', 'pantheon-content-publisher'), 400);
 		}
 
 		// Check if you are authorized
 		if (!current_user_can('manage_options')) {
-			return new WP_REST_Response(esc_html__('You are not authorized to perform this action.', 'pantheon-content-publisher-for-wordpress'), 401);
+			return new WP_REST_Response(esc_html__('You are not authorized to perform this action.', 'pantheon-content-publisher'), 401);
 		}
 
 		$siteManager = new PccSiteManager();
 		if ($siteManager->registerWebhook()) {
-			return new WP_REST_Response(esc_html__('Webhook registered', 'pantheon-content-publisher-for-wordpress'));
+			return new WP_REST_Response(esc_html__('Webhook registered', 'pantheon-content-publisher'));
 		}
 
-		return new WP_REST_Response(esc_html__('Error while register webhook', 'pantheon-content-publisher-for-wordpress'), 400);
+		return new WP_REST_Response(esc_html__('Error while register webhook', 'pantheon-content-publisher'), 400);
 	}
 
 	/**
@@ -246,22 +246,22 @@ class RestController
 	{
 		// Check site id is set
 		if (!get_option(CONTENT_PUB_SITE_ID_OPTION_KEY)) {
-			return new WP_REST_Response(esc_html__('Site is not created yet', 'pantheon-content-publisher-for-wordpress'), 400);
+			return new WP_REST_Response(esc_html__('Site is not created yet', 'pantheon-content-publisher'), 400);
 		}
 
 		// Check if you are authorized
 		if (!current_user_can('manage_options')) {
-			return new WP_REST_Response(esc_html__('You are not authorized to perform this action.', 'pantheon-content-publisher-for-wordpress'), 401);
+			return new WP_REST_Response(esc_html__('You are not authorized to perform this action.', 'pantheon-content-publisher'), 401);
 		}
 
 		$siteManager = new PccSiteManager();
 		$apiKey = $siteManager->createSiteApiKey();
 		if ($apiKey) {
 			update_option(CONTENT_PUB_API_KEY_OPTION_KEY, $apiKey);
-			return new WP_REST_Response(esc_html__('API created', 'pantheon-content-publisher-for-wordpress'));
+			return new WP_REST_Response(esc_html__('API created', 'pantheon-content-publisher'));
 		}
 
-		return new WP_REST_Response(esc_html__('Error while creating API key', 'pantheon-content-publisher-for-wordpress'), 400);
+		return new WP_REST_Response(esc_html__('Error while creating API key', 'pantheon-content-publisher'), 400);
 	}
 
 	/**
@@ -282,7 +282,7 @@ class RestController
 			update_option(CONTENT_PUB_INTEGRATION_POST_TYPE_OPTION_KEY, $postType);
 		}
 
-		return new WP_REST_Response(esc_html__('Saved!', 'pantheon-content-publisher-for-wordpress'));
+		return new WP_REST_Response(esc_html__('Saved!', 'pantheon-content-publisher'));
 	}
 
 	/**
@@ -295,7 +295,7 @@ class RestController
 	public function saveAccessToken(WP_REST_Request $request): WP_REST_Response
 	{
 		if (!current_user_can('manage_options')) {
-			return new WP_REST_Response(esc_html__('You are not authorized to perform this action.', 'pantheon-content-publisher-for-wordpress'), 401);
+			return new WP_REST_Response(esc_html__('You are not authorized to perform this action.', 'pantheon-content-publisher'), 401);
 		}
 
 		$accessToken = sanitize_text_field($request->get_param('access_token'));
@@ -303,14 +303,14 @@ class RestController
 		// Validate input field
 		if (empty($accessToken)) {
 			return new WP_REST_Response(
-				esc_html__('Management token cannot be empty.', 'pantheon-content-publisher-for-wordpress'),
+				esc_html__('Management token cannot be empty.', 'pantheon-content-publisher'),
 				400
 			);
 		}
 
 		update_option(CONTENT_PUB_ACCESS_TOKEN_OPTION_KEY, $accessToken);
 		return new WP_REST_Response(
-			esc_html__('Management token saved.', 'pantheon-content-publisher-for-wordpress'),
+			esc_html__('Management token saved.', 'pantheon-content-publisher'),
 			200
 		);
 	}
@@ -323,7 +323,7 @@ class RestController
 	public function disconnect()
 	{
 		if (!current_user_can('manage_options')) {
-			return new WP_REST_Response(esc_html__('You are not authorized to perform this action.', 'pantheon-content-publisher-for-wordpress'), 401);
+			return new WP_REST_Response(esc_html__('You are not authorized to perform this action.', 'pantheon-content-publisher'), 401);
 		}
 
 		// Disconnect the site
@@ -331,7 +331,7 @@ class RestController
 		$manager->disconnect();
 
 		return new WP_REST_Response(
-			esc_html__('Saved Data deleted.', 'pantheon-content-publisher-for-wordpress'),
+			esc_html__('Saved Data deleted.', 'pantheon-content-publisher'),
 			200
 		);
 	}

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -253,7 +253,7 @@ class Settings
 				if (empty($documentId) || empty($pccGrant)) {
 					wp_die(esc_html__(
 						'Content Publisher: Missing parameters for preview',
-						'pantheon-content-publisher-for-wordpress'
+						'pantheon-content-publisher'
 					));
 					exit;
 				}
@@ -287,7 +287,7 @@ class Settings
 						wp_die(esc_html__(
 							'Content Publisher: Failed to preview this document. Your preview link may have expired. ' .
 							'Try previewing this document again from Content Publisher.',
-							'pantheon-content-publisher-for-wordpress'
+							'pantheon-content-publisher'
 						));
 						$postId = 0;
 					}
@@ -298,7 +298,7 @@ class Settings
 						'Content Publisher: Failed to preview this document. ' .
 						'Confirm that this document is connected to your collection. ' .
 						'Reach out to support if the issue persists.',
-						'pantheon-content-publisher-for-wordpress'
+						'pantheon-content-publisher'
 					));
 					exit;
 				}
@@ -508,7 +508,7 @@ class Settings
 				$post->ID,
 				esc_html__(
 					'Edit in Google Docs',
-					'pantheon-content-publisher-for-wordpress'
+					'pantheon-content-publisher'
 				) . '<svg width="12px" height="12px" viewBox="0 0 24 24" style="display:inline">
                     <g stroke-width="2.1" stroke="#666" fill="none" stroke-linecap="round" stroke-linejoin="round">
                     <polyline points="17 13.5 17 19.5 5 19.5 5 7.5 11 7.5"></polyline>
@@ -533,10 +533,10 @@ class Settings
 	public function addMenu(): void
 	{
 		add_menu_page(
-			esc_html__('Pantheon Content Publisher', 'pantheon-content-publisher-for-wordpress'),
-			esc_html__('Pantheon Content Publisher', 'pantheon-content-publisher-for-wordpress'),
+			esc_html__('Pantheon Content Publisher', 'pantheon-content-publisher'),
+			esc_html__('Pantheon Content Publisher', 'pantheon-content-publisher'),
 			'manage_options',
-			'pantheon-content-publisher-for-wordpress',
+			'pantheon-content-publisher',
 			[$this, 'renderSettingsPage'],
 			$this->pccMenuIcon(),
 			20
@@ -589,7 +589,7 @@ class Settings
 	public function enqueueAdminAssets(): void
 	{
 		wp_enqueue_script(
-			'pantheon-content-publisher-for-wordpress',
+			'pantheon-content-publisher',
 			CONTENT_PUB_PLUGIN_DIR_URL . 'dist/app.js',
 			[],
 			filemtime(CONTENT_PUB_PLUGIN_DIR . 'dist/app.js'),
@@ -597,19 +597,19 @@ class Settings
 		);
 
 		wp_enqueue_style(
-			'pantheon-content-publisher-for-wordpress',
+			'pantheon-content-publisher',
 			CONTENT_PUB_PLUGIN_DIR_URL . 'dist/app.css',
 			[],
 			filemtime(CONTENT_PUB_PLUGIN_DIR . 'dist/app.css')
 		);
 
 		wp_localize_script(
-			'pantheon-content-publisher-for-wordpress',
+			'pantheon-content-publisher',
 			'PCCAdmin',
 			[
 				'rest_url' => get_rest_url(get_current_blog_id(), CONTENT_PUB_API_NAMESPACE),
 				'nonce' => wp_create_nonce('wp_rest'),
-				'plugin_main_page' => menu_page_url('pantheon-content-publisher-for-wordpress', false),
+				'plugin_main_page' => menu_page_url('pantheon-content-publisher', false),
 				'site_url' => site_url(),
 			]
 		);
@@ -630,7 +630,7 @@ class Settings
 		}
 
 		wp_enqueue_script(
-			'pantheon-content-publisher-for-wordpress',
+			'pantheon-content-publisher',
 			CONTENT_PUB_PLUGIN_DIR_URL . 'dist/pcc-front.js',
 			[],
 			filemtime(CONTENT_PUB_PLUGIN_DIR . 'dist/pcc-front.js'),
@@ -638,7 +638,7 @@ class Settings
 		);
 
 		wp_localize_script(
-			'pantheon-content-publisher-for-wordpress',
+			'pantheon-content-publisher',
 			'PCCFront',
 			[
 				'site_id' => sanitize_text_field(wp_unslash($this->getSiteId())),

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
   description: A PCC publisher module for publishing wordpress content
   annotations:
     pantheon.io/service-catalog/subdir: /
-    github.com/project-slug: pantheon-systems/pantheon-content-publisher-for-wordpress
+    github.com/project-slug: pantheon-systems/pantheon-content-publisher
     github.com/team-slug: pantheon-systems/pcc
 spec:
   type: library

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pantheon-systems/pantheon-content-publisher-for-wordpress",
+  "name": "pantheon-systems/pantheon-content-publisher",
   "type": "wordpress-plugin",
   "description": "Publish WordPress content from Google Docs with Pantheon Content Cloud.",
   "keywords": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pantheon-content-publisher-for-wordpress",
+  "name": "pantheon-content-publisher",
   "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pantheon-content-publisher-for-wordpress",
+      "name": "pantheon-content-publisher",
       "version": "1.2.4",
       "dependencies": {
         "@pantheon-systems/pcc-sdk-core": "3.11.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pantheon-content-publisher-for-wordpress",
+  "name": "pantheon-content-publisher",
   "version": "1.2.6",
   "description": "Publish WordPress content from Google Docs with Pantheon Content Cloud.",
   "scripts": {

--- a/pantheon-content-publisher.php
+++ b/pantheon-content-publisher.php
@@ -5,7 +5,7 @@
 /**
  * Plugin Name: Pantheon Content Publisher
  * Description: Publish WordPress content from Google Docs with Pantheon Content Cloud.
- * Plugin URI: https://github.com/pantheon-systems/pantheon-content-publisher-for-wordpress/
+ * Plugin URI: https://github.com/pantheon-systems/pantheon-content-publisher/
  * Author: Pantheon
  * Author URI: https://pantheon.io
  * Version: 1.2.6


### PR DESCRIPTION
To prepare for the WordPress Plugin submission, we are removing the -for-wordpress slug from the plugin name and all instances of it. 
I have applied the changes to my site's plugin directly and noticed no specific issues related to the slug change.

## Checklist:
- [x] I've tested the code, but not the composer-built version