### PR TITLE
Fix translation strings

### DIFF
--- a/app/Settings.php
+++ b/app/Settings.php
@@ -285,8 +285,7 @@ class Settings
 						);
 					} catch (Exception $ex) {
 						wp_die(esc_html__(
-							'Content Publisher: Failed to preview this document. Your preview link may have expired. ' .
-							'Try previewing this document again from Content Publisher.',
+							'Content Publisher: Failed to preview this document. Your preview link may have expired. Try previewing this document again from Content Publisher.',
 							'pantheon-content-publisher-for-wordpress'
 						));
 						$postId = 0;
@@ -295,9 +294,7 @@ class Settings
 
 				if (empty($postId) || !is_numeric($postId) || $postId <= 0) {
 					wp_die(esc_html__(
-						'Content Publisher: Failed to preview this document. ' .
-						'Confirm that this document is connected to your collection. ' .
-						'Reach out to support if the issue persists.',
+						'Content Publisher: Failed to preview this document. Confirm that this document is connected to your collection. Reach out to support if the issue persists.',
 						'pantheon-content-publisher-for-wordpress'
 					));
 					exit;


### PR DESCRIPTION
Translation strings were broken into pieces. Plugin review failed because they should be a single string. Multiple strings would cause confusion (and potentially problems) for translation.
